### PR TITLE
Rm unused args, fix numbered list

### DIFF
--- a/docs/quickstart.adoc
+++ b/docs/quickstart.adoc
@@ -44,7 +44,7 @@ git clone https://github.com/oracle/terraform-oci-base.git tfbase
 cd tfbase
 cp terraform.tfvars.example terraform.tfvars
 ----
-
+[start=2]
 2. Set mandatory parameters in terraform.tfvars:
 
 * api_fingerprint
@@ -64,8 +64,6 @@ cp terraform.tfvars.example terraform.tfvars
 * vcn_dns_label
 * vcn_name
 * create_bastion
-* cluster_name
-* worker_mode
 
 5. Create a provider.tf file and add the following:
 


### PR DESCRIPTION
cluster_name and worker_mode were unused in terraform-oci-base outside of the quickstart doc

$ grep -R cluster_name *
docs/quickstart.adoc:* cluster_name
$ grep -R worker_mode *
docs/quickstart.adoc:* worker_mode

They are used in terrafrom-oci-oke, but not in terrafrom-oci-base.

Also fixed adoc-style numbered list (#1 was doubled)