### PR TITLE
Tagging for base module 

### DIFF
--- a/examples/db/locals.tf
+++ b/examples/db/locals.tf
@@ -65,6 +65,8 @@ locals {
     use_autonomous            = var.admin_use_autonomous
   }
 
+  tagging = var.tagging
+
   db_identity = {
     compartment_id = var.compartment_id
     tenancy_id     = var.tenancy_id

--- a/examples/db/main.tf
+++ b/examples/db/main.tf
@@ -18,6 +18,9 @@ module "base" {
 
   # admin parameters
   oci_base_admin = local.oci_base_admin
+
+  #tagging
+  tagging = local.tagging
 }
 
 module "db" {

--- a/examples/db/terraform.tfvars.example
+++ b/examples/db/terraform.tfvars.example
@@ -98,6 +98,9 @@ availability_domains = {
   db      = 1
 }
 
+tagging = {"Environment"="UAT"
+           "Owner"="Admin"}
+           
 # db
 
 db_system_shape = "VM.Standard2.8"

--- a/examples/db/variables.tf
+++ b/examples/db/variables.tf
@@ -354,3 +354,7 @@ variable "data_storage_percentage" {
   default = 40
   type    = number
 }
+
+variable "tagging" {
+  type = map(any)
+}

--- a/main.tf
+++ b/main.tf
@@ -4,17 +4,17 @@
 module "vcn" {
   source       = "./modules/vcn"
   oci_base_vcn = local.oci_base_vcn
-  tagging = var.tagging
+  tagging      = var.tagging
 }
 
 module "bastion" {
   source                   = "./modules/bastion"
   oci_base_identity        = var.oci_base_identity
   oci_bastion_general      = local.oci_bastion_general
-  oci_bastion_network        = local.oci_bastion_network
+  oci_bastion_network      = local.oci_bastion_network
   oci_bastion              = local.oci_bastion
   oci_bastion_notification = local.oci_bastion_notification
-  tagging = var.tagging
+  tagging                  = var.tagging
 }
 
 module "admin" {
@@ -24,5 +24,5 @@ module "admin" {
   oci_admin_network      = local.oci_admin_network
   oci_admin              = local.oci_admin
   oci_admin_notification = local.oci_admin_notification
-  tagging = var.tagging
+  tagging                = var.tagging
 }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@
 module "vcn" {
   source       = "./modules/vcn"
   oci_base_vcn = local.oci_base_vcn
+  tagging = var.tagging
 }
 
 module "bastion" {
@@ -13,6 +14,7 @@ module "bastion" {
   oci_bastion_network        = local.oci_bastion_network
   oci_bastion              = local.oci_bastion
   oci_bastion_notification = local.oci_bastion_notification
+  tagging = var.tagging
 }
 
 module "admin" {
@@ -22,4 +24,5 @@ module "admin" {
   oci_admin_network      = local.oci_admin_network
   oci_admin              = local.oci_admin
   oci_admin_notification = local.oci_admin_notification
+  tagging = var.tagging
 }

--- a/modules/admin/compute.tf
+++ b/modules/admin/compute.tf
@@ -4,6 +4,7 @@
 resource "oci_core_instance" "admin" {
   availability_domain = element(var.oci_admin_network.ad_names, (var.oci_admin_network.availability_domains - 1))
   compartment_id      = var.oci_admin_identity.compartment_id
+  freeform_tags       = var.tagging
 
   create_vnic_details {
     assign_public_ip = false

--- a/modules/admin/instance_principal.tf
+++ b/modules/admin/instance_principal.tf
@@ -28,7 +28,7 @@ resource "oci_identity_dynamic_group" "admin_instance_principal" {
   description    = "dynamic group to allow instances to call services for 1 admin"
   matching_rule  = "ALL {instance.id = '${join(",", data.oci_core_instance.admin.*.id)}'}"
   name           = "${var.oci_admin_general.label_prefix}-admin_instance_principal"
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
   count          = var.oci_admin.admin_enabled == true && var.oci_admin.enable_instance_principal == true ? 1 : 0
 }
 
@@ -38,6 +38,6 @@ resource "oci_identity_policy" "admin_instance_principal" {
   description    = "policy to allow admin host to call services"
   name           = "${var.oci_admin_general.label_prefix}-admin_instance_principal"
   statements     = ["Allow dynamic-group ${oci_identity_dynamic_group.admin_instance_principal[0].name} to manage all-resources in compartment id ${data.oci_identity_compartments.compartments_id.compartments.0.id}"]
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
   count          = var.oci_admin.admin_enabled == true && var.oci_admin.enable_instance_principal == true ? 1 : 0
 }

--- a/modules/admin/instance_principal.tf
+++ b/modules/admin/instance_principal.tf
@@ -28,6 +28,7 @@ resource "oci_identity_dynamic_group" "admin_instance_principal" {
   description    = "dynamic group to allow instances to call services for 1 admin"
   matching_rule  = "ALL {instance.id = '${join(",", data.oci_core_instance.admin.*.id)}'}"
   name           = "${var.oci_admin_general.label_prefix}-admin_instance_principal"
+  freeform_tags       = var.tagging
   count          = var.oci_admin.admin_enabled == true && var.oci_admin.enable_instance_principal == true ? 1 : 0
 }
 
@@ -37,5 +38,6 @@ resource "oci_identity_policy" "admin_instance_principal" {
   description    = "policy to allow admin host to call services"
   name           = "${var.oci_admin_general.label_prefix}-admin_instance_principal"
   statements     = ["Allow dynamic-group ${oci_identity_dynamic_group.admin_instance_principal[0].name} to manage all-resources in compartment id ${data.oci_identity_compartments.compartments_id.compartments.0.id}"]
+  freeform_tags       = var.tagging
   count          = var.oci_admin.admin_enabled == true && var.oci_admin.enable_instance_principal == true ? 1 : 0
 }

--- a/modules/admin/subnets.tf
+++ b/modules/admin/subnets.tf
@@ -10,7 +10,7 @@ resource "oci_core_subnet" "admin" {
   route_table_id             = var.oci_admin_network.nat_route_id
   security_list_ids          = [oci_core_security_list.admin[0].id]
   vcn_id                     = var.oci_admin_network.vcn_id
-  freeform_tags       = var.tagging
+  freeform_tags              = var.tagging
 
   count = var.oci_admin.admin_enabled == true ? 1 : 0
 }

--- a/modules/admin/subnets.tf
+++ b/modules/admin/subnets.tf
@@ -10,6 +10,7 @@ resource "oci_core_subnet" "admin" {
   route_table_id             = var.oci_admin_network.nat_route_id
   security_list_ids          = [oci_core_security_list.admin[0].id]
   vcn_id                     = var.oci_admin_network.vcn_id
+  freeform_tags       = var.tagging
 
   count = var.oci_admin.admin_enabled == true ? 1 : 0
 }

--- a/modules/admin/variables.tf
+++ b/modules/admin/variables.tf
@@ -55,3 +55,7 @@ variable "oci_admin_notification" {
     notification_topic    = string
   })
 }
+
+variable "tagging" {
+  type = map(any)
+}

--- a/modules/bastion/compute.tf
+++ b/modules/bastion/compute.tf
@@ -4,6 +4,7 @@
 resource "oci_core_instance" "bastion" {
   availability_domain = element(var.oci_bastion_network.ad_names, (var.oci_bastion_network.availability_domains - 1))
   compartment_id      = var.oci_base_identity.compartment_id
+  freeform_tags       = var.tagging
 
   create_vnic_details {
     assign_public_ip = true

--- a/modules/bastion/ons.tf
+++ b/modules/bastion/ons.tf
@@ -25,7 +25,7 @@ resource "oci_ons_notification_topic" "bastion_notification" {
   #Required
   compartment_id = var.oci_base_identity.compartment_id
   name           = "${var.oci_bastion_general.label_prefix}-${var.oci_bastion_notification.notification_topic}"
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
   count          = var.oci_bastion_notification.notification_enabled == true ? 1 : 0
 }
 
@@ -35,7 +35,7 @@ resource "oci_ons_subscription" "bastion_notification" {
   endpoint       = var.oci_bastion_notification.notification_endpoint
   protocol       = var.oci_bastion_notification.notification_protocol
   topic_id       = oci_ons_notification_topic.bastion_notification[0].topic_id
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
   count          = var.oci_bastion_notification.notification_enabled == true ? 1 : 0
 }
 
@@ -46,7 +46,7 @@ resource "oci_identity_dynamic_group" "bastion_notification" {
   matching_rule  = "ALL {instance.id = '${join(",", data.oci_core_instance.bastion.*.id)}'}"
   name           = "${var.oci_bastion_general.label_prefix}-bastion-notification"
   depends_on     = [oci_core_instance.bastion]
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
   count          = var.oci_bastion_notification.notification_enabled == true && var.oci_bastion.bastion_enabled == true ? 1 : 0
 }
 
@@ -57,6 +57,6 @@ resource "oci_identity_policy" "bastion_notification" {
   name           = "${var.oci_bastion_general.label_prefix}-bastion-notification"
   statements     = ["Allow dynamic-group ${oci_identity_dynamic_group.bastion_notification[0].name} to use ons-topic in compartment id ${data.oci_identity_compartments.compartments_id.compartments.0.id} where request.permission='ONS_TOPIC_PUBLISH'"]
   depends_on     = [oci_core_instance.bastion]
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
   count          = var.oci_bastion.bastion_enabled == true && var.oci_bastion_notification.notification_enabled == true ? 1 : 0
 }

--- a/modules/bastion/ons.tf
+++ b/modules/bastion/ons.tf
@@ -25,6 +25,7 @@ resource "oci_ons_notification_topic" "bastion_notification" {
   #Required
   compartment_id = var.oci_base_identity.compartment_id
   name           = "${var.oci_bastion_general.label_prefix}-${var.oci_bastion_notification.notification_topic}"
+  freeform_tags       = var.tagging
   count          = var.oci_bastion_notification.notification_enabled == true ? 1 : 0
 }
 
@@ -34,6 +35,7 @@ resource "oci_ons_subscription" "bastion_notification" {
   endpoint       = var.oci_bastion_notification.notification_endpoint
   protocol       = var.oci_bastion_notification.notification_protocol
   topic_id       = oci_ons_notification_topic.bastion_notification[0].topic_id
+  freeform_tags       = var.tagging
   count          = var.oci_bastion_notification.notification_enabled == true ? 1 : 0
 }
 
@@ -44,6 +46,7 @@ resource "oci_identity_dynamic_group" "bastion_notification" {
   matching_rule  = "ALL {instance.id = '${join(",", data.oci_core_instance.bastion.*.id)}'}"
   name           = "${var.oci_bastion_general.label_prefix}-bastion-notification"
   depends_on     = [oci_core_instance.bastion]
+  freeform_tags       = var.tagging
   count          = var.oci_bastion_notification.notification_enabled == true && var.oci_bastion.bastion_enabled == true ? 1 : 0
 }
 
@@ -54,5 +57,6 @@ resource "oci_identity_policy" "bastion_notification" {
   name           = "${var.oci_bastion_general.label_prefix}-bastion-notification"
   statements     = ["Allow dynamic-group ${oci_identity_dynamic_group.bastion_notification[0].name} to use ons-topic in compartment id ${data.oci_identity_compartments.compartments_id.compartments.0.id} where request.permission='ONS_TOPIC_PUBLISH'"]
   depends_on     = [oci_core_instance.bastion]
+  freeform_tags       = var.tagging
   count          = var.oci_bastion.bastion_enabled == true && var.oci_bastion_notification.notification_enabled == true ? 1 : 0
 }

--- a/modules/bastion/subnets.tf
+++ b/modules/bastion/subnets.tf
@@ -10,6 +10,7 @@ resource "oci_core_subnet" "bastion" {
   route_table_id             = var.oci_bastion_network.ig_route_id
   security_list_ids          = [oci_core_security_list.bastion[0].id]
   vcn_id                     = var.oci_bastion_network.vcn_id
+  freeform_tags       = var.tagging
 
   count = var.oci_bastion.bastion_enabled == true ? 1 : 0
 }

--- a/modules/bastion/subnets.tf
+++ b/modules/bastion/subnets.tf
@@ -10,7 +10,7 @@ resource "oci_core_subnet" "bastion" {
   route_table_id             = var.oci_bastion_network.ig_route_id
   security_list_ids          = [oci_core_security_list.bastion[0].id]
   vcn_id                     = var.oci_bastion_network.vcn_id
-  freeform_tags       = var.tagging
+  freeform_tags              = var.tagging
 
   count = var.oci_bastion.bastion_enabled == true ? 1 : 0
 }

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -61,3 +61,7 @@ variable "oci_bastion_notification" {
   })
   description = "OCI notification parameters for bastion"
 }
+
+variable "tagging" {
+  type = map(any)
+}

--- a/modules/vcn/nat.tf
+++ b/modules/vcn/nat.tf
@@ -5,6 +5,7 @@ resource "oci_core_nat_gateway" "nat_gateway" {
   compartment_id = var.oci_base_vcn.compartment_id
   display_name   = "${var.oci_base_vcn.label_prefix}-nat-gw"
   vcn_id         = oci_core_vcn.vcn.id
+  freeform_tags       = var.tagging
   count          = var.oci_base_vcn.nat_gateway_enabled == true ? 1 : 0
 }
 

--- a/modules/vcn/nat.tf
+++ b/modules/vcn/nat.tf
@@ -5,7 +5,7 @@ resource "oci_core_nat_gateway" "nat_gateway" {
   compartment_id = var.oci_base_vcn.compartment_id
   display_name   = "${var.oci_base_vcn.label_prefix}-nat-gw"
   vcn_id         = oci_core_vcn.vcn.id
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
   count          = var.oci_base_vcn.nat_gateway_enabled == true ? 1 : 0
 }
 

--- a/modules/vcn/servicegateway.tf
+++ b/modules/vcn/servicegateway.tf
@@ -14,6 +14,7 @@ resource "oci_core_service_gateway" "service_gateway" {
   compartment_id = var.oci_base_vcn.compartment_id
   display_name   = "${var.oci_base_vcn.label_prefix}-sg-gw"
   depends_on     = [oci_core_nat_gateway.nat_gateway]
+  freeform_tags       = var.tagging
 
   services {
     service_id = lookup(data.oci_core_services.all_oci_services[0].services[0], "id")

--- a/modules/vcn/servicegateway.tf
+++ b/modules/vcn/servicegateway.tf
@@ -14,7 +14,7 @@ resource "oci_core_service_gateway" "service_gateway" {
   compartment_id = var.oci_base_vcn.compartment_id
   display_name   = "${var.oci_base_vcn.label_prefix}-sg-gw"
   depends_on     = [oci_core_nat_gateway.nat_gateway]
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
 
   services {
     service_id = lookup(data.oci_core_services.all_oci_services[0].services[0], "id")

--- a/modules/vcn/variables.tf
+++ b/modules/vcn/variables.tf
@@ -13,3 +13,7 @@ variable "oci_base_vcn" {
   })
   description = "vcn basic parameters"
 }
+
+variable "tagging" {
+  type = map(any)
+}

--- a/modules/vcn/vcn.tf
+++ b/modules/vcn/vcn.tf
@@ -6,7 +6,7 @@ resource "oci_core_vcn" "vcn" {
   compartment_id = var.oci_base_vcn.compartment_id
   display_name   = "${var.oci_base_vcn.label_prefix}-${var.oci_base_vcn.vcn_name}"
   dns_label      = var.oci_base_vcn.vcn_dns_label
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
 }
 
 resource "oci_core_internet_gateway" "ig" {

--- a/modules/vcn/vcn.tf
+++ b/modules/vcn/vcn.tf
@@ -13,7 +13,7 @@ resource "oci_core_internet_gateway" "ig" {
   compartment_id = var.oci_base_vcn.compartment_id
   display_name   = "${var.oci_base_vcn.label_prefix}-ig-gw"
   vcn_id         = oci_core_vcn.vcn.id
-  freeform_tags       = var.tagging
+  freeform_tags  = var.tagging
 }
 
 resource "oci_core_route_table" "ig_route" {

--- a/modules/vcn/vcn.tf
+++ b/modules/vcn/vcn.tf
@@ -6,12 +6,14 @@ resource "oci_core_vcn" "vcn" {
   compartment_id = var.oci_base_vcn.compartment_id
   display_name   = "${var.oci_base_vcn.label_prefix}-${var.oci_base_vcn.vcn_name}"
   dns_label      = var.oci_base_vcn.vcn_dns_label
+  freeform_tags       = var.tagging
 }
 
 resource "oci_core_internet_gateway" "ig" {
   compartment_id = var.oci_base_vcn.compartment_id
   display_name   = "${var.oci_base_vcn.label_prefix}-ig-gw"
   vcn_id         = oci_core_vcn.vcn.id
+  freeform_tags       = var.tagging
 }
 
 resource "oci_core_route_table" "ig_route" {

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -63,3 +63,6 @@ oci_base_admin = {
   timezone                  = "Australia/Sydney"
   use_autonomous            = false
 }
+
+tagging = {"Environment"="UAT"
+           "Owner"="Admin"}

--- a/variables.tf
+++ b/variables.tf
@@ -131,3 +131,7 @@ variable "oci_base_admin" {
     use_autonomous            = false
   }
 }
+
+variable "tagging" {
+  type = map(any)
+}


### PR DESCRIPTION
Tagging has been enabled for compute,VCN,gateways. It's not done for security list and route tables as felt unnecessary.