### PR TITLE
additional check on data.oci_ons_notification_topic.oci_ons_notificat…

### DIFF
--- a/modules/bastion/datasources.tf
+++ b/modules/bastion/datasources.tf
@@ -67,5 +67,5 @@ data "oci_core_instance" "bastion" {
 data "oci_ons_notification_topic" "bastion_notification" {
   #Required
   topic_id = oci_ons_notification_topic.bastion_notification[0].topic_id
-  count    = var.oci_bastion_notification.notification_enabled == true ? 1 : 0
+  count    = (var.oci_bastion.bastion_enabled == true && var.oci_bastion_notification.notification_enabled == true) ? 1 : 0
 }


### PR DESCRIPTION
…ion_topic to ensure the datasource is created only if bastion is created.

Signed-off-by: Ali Mukadam <ali.mukadam@oracle.com>