### PR TITLE
Update terraformoptions.adoc for Issue #57 label prefix optional

### DIFF
--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -74,7 +74,7 @@ Configuration Terraform Options:
 |None
 
 |label_prefix
-|a string to be prepended to the name of resources. *Recommended*
+|a string to be prepended to the name of resources. *Recommended*.Set to *"none"* if you dont want any prefix.
 |
 |
 


### PR DESCRIPTION
Updated the document and mentioned set label_prefix to none if you don't want prefix